### PR TITLE
Removing state pollution in `maker.merge` and `mocked_makedirs`

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -64,6 +64,7 @@ def test_create_package_dir(mocked_mkdir, mocked_makedirs, maker1, maker2):
         assert maker1._create_package_dir() == -1
         mocked_mkdir.assert_not_called()
         mocked_makedirs.assert_not_called()
+        maker1.merge = False
     with mock.patch('os.path.exists', return_value=False):
         # merge == False && format == 'src'
         assert maker2._create_package_dir() == 1
@@ -74,6 +75,8 @@ def test_create_package_dir(mocked_mkdir, mocked_makedirs, maker1, maker2):
         assert maker2._create_package_dir() == 1
         mocked_mkdir.assert_not_called()
         assert mocked_makedirs.called
+        maker2.merge = False
+        mocked_makedirs.call_count = 0
 
 
 @mock.patch('os.fsync')


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_create_package_dir` by removing state pollution in `maker.merge` and `mocked_makedirs`.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_package.py::test_create_package_dir`:

```
        with mock.patch('os.path.exists', return_value=True):
            # merge == False && format == 'basic'
>           assert maker1._create_package_dir() == 0
E           assert -1 == 0
E             +-1
E             -0
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
