### PR TITLE
Removing state pollution in `test_write_init`

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -91,6 +91,7 @@ def test_write_init(mocked_fsync, maker1):
             maker1.force = True
             assert maker1._write_init()
             assert mocked_open().write.called
+            maker1.force = False
         with mock.patch('os.path.exists', return_value=False):
             # not exist
             assert maker1._write_init()


### PR DESCRIPTION
The test `test_write_init` would fail due to the same reason with #2.