### PR TITLE
Removing state pollution in `test_file`

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -43,7 +43,7 @@ expected = ("#!/usr/bin/env python - shebang will remain.\n"
             "    # Environment :: Win32 (MS Windows) # what about this?\n")
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def test_file():
     testFile = os.path.join(gettempdir(), 'test_file')
     with open(testFile, 'wt') as f:


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_remove_comment_line_in_file` by removing state pollution in `test_file` by altering `pytest.fixture` scope from `module` to `function`.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_helpers.py::test_remove_comment_line_in_file`:

```
        helpers.remove_comment_lines_in_file(test_file, destFile)
        with open(test_file, 'r') as f:
            data = f.read()
>       assert data == test_data
E       AssertionError: assert '#!/usr/bin/e...about this?\n' == '#!/usr/bin/e...about this?\n'
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
